### PR TITLE
Add repository option to specify GitHub repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,14 @@ llm install llm-openhands
 ```
 ## Usage
 
+Here's an example from https://www.all-hands.dev/blog/programmatically-access-coding-agents-with-the-openhands-cloud-api
+
 **prerequisite**: OpenHands Cloud API key  
 https://docs.all-hands.dev/modules/usage/cloud/cloud-api#obtaining-an-api-key
 
 ```bash
 export LLM_OPENHANDS_KEY=your_api_key_here
 
-# Basic usage
-llm -m openhands "Hello, OpenHands"
-
-# Using with a GitHub repository
 llm -m openhands "Check for the authentication module to make sure that it follows the coding best practices for this repo." -o repository https://github.com/yourusername/your-repo
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ https://docs.all-hands.dev/modules/usage/cloud/cloud-api#obtaining-an-api-key
 ```bash
 export LLM_OPENHANDS_KEY=your_api_key_here
 
-llm -m devin "Hello, OpenHands"
+# Basic usage
+llm -m openhands "Hello, OpenHands"
+
+# Using with a GitHub repository
+llm -m openhands "Check for the authentication module to make sure that it follows the coding best practices for this repo." -o repository https://github.com/yourusername/your-repo
 ```
 
 ## Development

--- a/llm_openhands.py
+++ b/llm_openhands.py
@@ -1,7 +1,9 @@
 import time
+from typing import Optional
 
 import httpx
 import llm
+from pydantic import Field
 
 
 class OpenHandsModel(llm.KeyModel):
@@ -9,11 +11,22 @@ class OpenHandsModel(llm.KeyModel):
     key_env_var = "LLM_OPENHANDS_KEY"
     can_stream = False
 
+    class Options(llm.Options):
+        repository: Optional[str] = Field(
+            description="GitHub repository URL to analyze",
+            default=None
+        )
+
     def __init__(self):
         self.model_id = "openhands"
 
     def execute(self, prompt, stream, response, conversation, key):
         request_json = {"initial_user_msg": prompt.prompt}
+        
+        # Add repository URL to the request if provided
+        if prompt.options.repository:
+            request_json["repository"] = prompt.options.repository
+            
         create_conversation_response = httpx.post(
             "https://app.all-hands.dev/api/conversations",
             headers={"Authorization": f"Bearer {key}"},

--- a/llm_openhands.py
+++ b/llm_openhands.py
@@ -13,8 +13,7 @@ class OpenHandsModel(llm.KeyModel):
 
     class Options(llm.Options):
         repository: Optional[str] = Field(
-            description="GitHub repository URL to analyze",
-            default=None
+            description="GitHub repository URL to analyze", default=None
         )
 
     def __init__(self):
@@ -22,11 +21,9 @@ class OpenHandsModel(llm.KeyModel):
 
     def execute(self, prompt, stream, response, conversation, key):
         request_json = {"initial_user_msg": prompt.prompt}
-        
-        # Add repository URL to the request if provided
         if prompt.options.repository:
             request_json["repository"] = prompt.options.repository
-            
+
         create_conversation_response = httpx.post(
             "https://app.all-hands.dev/api/conversations",
             headers={"Authorization": f"Bearer {key}"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,4 @@ CI = "https://github.com/ftnext/llm-openhands/actions"
 openhands = "llm_openhands"
 
 [project.optional-dependencies]
-test = ["pytest", "respx>=0.22.0"]
+test = ["pytest", "pytest-randomly", "respx>=0.22.0"]

--- a/tests/test_openhands.py
+++ b/tests/test_openhands.py
@@ -15,7 +15,7 @@ def test_plugin_is_installed():
 
 
 @respx.mock
-def test_execute(respx_mock):
+def test_execute_without_repository(respx_mock):
     respx_mock.post(
         "https://app.all-hands.dev/api/conversations",
         headers__contains={"Authorization": "Bearer test-api-key"},
@@ -99,12 +99,14 @@ def test_execute(respx_mock):
 
 
 @respx.mock
-def test_execute_with_repository(respx_mock):
-    repo_url = "https://github.com/yourusername/your-repo"
+def test_execute(respx_mock):
     respx_mock.post(
         "https://app.all-hands.dev/api/conversations",
         headers__contains={"Authorization": "Bearer test-api-key"},
-        json__eq={"initial_user_msg": "Check the code", "repository": repo_url},
+        json__eq={
+            "initial_user_msg": "Check the code",
+            "repository": "https://github.com/yourusername/your-repo",
+        },
     ).mock(
         return_value=httpx.Response(
             status_code=200,
@@ -146,7 +148,7 @@ def test_execute_with_repository(respx_mock):
     prompt = MagicMock()
     prompt.prompt = "Check the code"
     prompt.options = MagicMock()
-    prompt.options.repository = repo_url
+    prompt.options.repository = "https://github.com/yourusername/your-repo"
 
     actual = list(
         sut.execute(

--- a/uv.lock
+++ b/uv.lock
@@ -168,6 +168,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -285,6 +297,7 @@ dependencies = [
 [package.optional-dependencies]
 test = [
     { name = "pytest" },
+    { name = "pytest-randomly" },
     { name = "respx" },
 ]
 
@@ -293,6 +306,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "llm" },
     { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-randomly", marker = "extra == 'test'" },
     { name = "respx", marker = "extra == 'test'", specifier = ">=0.22.0" },
 ]
 provides-extras = ["test"]
@@ -500,6 +514,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/68/d221ed7f4a2a49a664da721b8e87b52af6dd317af2a6cb51549cf17ac4b8/pytest_randomly-3.16.0.tar.gz", hash = "sha256:11bf4d23a26484de7860d82f726c0629837cf4064b79157bd18ec9d41d7feb26", size = 13367 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/70/b31577d7c46d8e2f9baccfed5067dd8475262a2331ffb0bfdf19361c9bde/pytest_randomly-3.16.0-py3-none-any.whl", hash = "sha256:8633d332635a1a0983d3bba19342196807f6afb17c3eef78e02c2f85dade45d6", size = 8396 },
 ]
 
 [[package]]
@@ -733,4 +760,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
+]
+
+[[package]]
+name = "zipp"
+version = "3.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630 },
 ]


### PR DESCRIPTION
This PR adds a new repository option to the OpenHandsModel class that allows users to specify a GitHub repository URL when using the llm command.

Resolves #1